### PR TITLE
ロード時に決定キー連打でセーブデータが消える不具合を修正

### DIFF
--- a/FTKR_DeleteSavefile.js
+++ b/FTKR_DeleteSavefile.js
@@ -318,6 +318,7 @@ FTKR.DSF = FTKR.DSF || {};
         this._confCommandWindow.setHandler('cancel', this.onConfirmationCancel.bind(this));
         this.addWindow(this._confCommandWindow);
         this._confCommandWindow.hide();
+        this._confCommandWindow.deactivate();
     };
 
     Scene_File.prototype.onListOk = function() {


### PR DESCRIPTION
# 概要
セーブデータをロードする際、決定キーを連打するとセーブデータが消える不具合を修正します。
確認ウィンドウが hide で隠されているだけで、アクティブなままであるため、決定キーの入力を受け付けてしまうようです。